### PR TITLE
Allow filtering upcoming events by eventtype

### DIFF
--- a/src/UNL/UCBCN/Calendar/EventType.php
+++ b/src/UNL/UCBCN/Calendar/EventType.php
@@ -68,5 +68,10 @@ class EventType extends Record
     {
         return array('calendar_id' => 'calendar:id');
     }
+
+    public static function getByName($name)
+    {
+        return self::getByAnyField(__CLASS__, 'name', $name);
+    }
     
 }


### PR DESCRIPTION
This will allow you to filter events on the upcoming list to specific event types. For example:
`/upcoming?eventtype=camp` would only show events that have the 'camp' type
`/upcoming?eventtype=special%20event` would only show events that have the 'special event' type

This could then be used in conjunction with the framework events widget to only show upcoming events of a specific type. I don't think the type is being used anywhere else, so this might be a helpful way of using it.

I've seen a few requests for is sort of functionality come through, so I thought I'd take a stab at it.

Whatcha think?
