### PR TITLE
Require room/new-location-room to recommend to UNL Main Calendar

### DIFF
--- a/src/UNL/UCBCN/Manager/CreateEvent.php
+++ b/src/UNL/UCBCN/Manager/CreateEvent.php
@@ -75,8 +75,13 @@ class CreateEvent extends PostHandler
 
         # if we are sending this to UNL Main Calendar, description and contact info must be given
         if (array_key_exists('send_to_main', $post_data) && $post_data['send_to_main'] == 'on') {
-            if (empty($post_data['description']) || empty($post_data['contact_name'])) {
-                throw new ValidationException('<a href="#contact-name">Contact name</a> and <a href="#description">description</a> are required to recommend to UNL Main Calendar.');
+            if (empty($post_data['description']) || empty($post_data['contact_name']) || ( empty($post_data['room']) && !($post_data['location'] == 'new' && !empty($post_data['new_location']['room'])))) {
+                if($post_data['location'] == 'new'){
+                    throw new ValidationException('<a href="#contact-name">Contact name</a>, <a href="#description">description</a> and <a href="#room">room</a>/<a href="#location-room">location-room</a> are required to recommend to UNL Main Calendar.');
+                }
+                else{
+                    throw new ValidationException('<a href="#contact-name">Contact name</a>, <a href="#description">description</a> and <a href="#room">room</a> are required to recommend to UNL Main Calendar.');
+                }
             }
         }
 

--- a/www/templates/default/html/manager/CreateEvent.tpl.php
+++ b/www/templates/default/html/manager/CreateEvent.tpl.php
@@ -60,48 +60,48 @@
                 <div id="new-location-fields" style="display: none;">
                     <h6>New Location</h6>
                     <label for="location-name"><span class="required">*</span> Name</label>
-                    <input type="text" id="location-name" name="new_location[name]" value="<?php echo $post['location']['name']; ?>">
+                    <input type="text" id="location-name" name="new_location[name]" value="<?php echo $post['new_location']['name']; ?>">
 
                     <label for="location-address-1">Address</label>
-                    <input type="text" id="location-address-1" name="new_location[streetaddress1]" value="<?php echo $post['location']['streetaddress1']; ?>">
+                    <input type="text" id="location-address-1" name="new_location[streetaddress1]" value="<?php echo $post['new_location']['streetaddress1']; ?>">
 
                     <label for="location-address-2">Address 2</label>
-                    <input type="text" id="location-address-2" name="new_location[streetaddress2]" value="<?php echo $post['location']['streetaddress2']; ?>">
+                    <input type="text" id="location-address-2" name="new_location[streetaddress2]" value="<?php echo $post['new_location']['streetaddress2']; ?>">
 
                     <label for="location-room">Room</label>
-                    <input type="text" id="location-room" name="new_location[room]" value="<?php echo $post['location']['room']; ?>">
+                    <input type="text" id="location-room" name="new_location[room]" value="<?php echo $post['new_location']['room']; ?>">
 
                     <label for="location-city">City</label>
-                    <input type="text" id="location-city" name="new_location[city]" value="<?php echo $post['location']['city']; ?>">
+                    <input type="text" id="location-city" name="new_location[city]" value="<?php echo $post['new_location']['city']; ?>">
 
                     <label for="location-state">State</label>
-                    <input type="text" id="location-state" name="new_location[state]" value="<?php echo $post['location']['state']; ?>">
+                    <input type="text" id="location-state" name="new_location[state]" value="<?php echo $post['new_location']['state']; ?>">
 
                     <label for="location-zip">Zip</label>
-                    <input type="text" id="location-zip" name="new_location[zip]" value="<?php echo $post['location']['zip']; ?>">
+                    <input type="text" id="location-zip" name="new_location[zip]" value="<?php echo $post['new_location']['zip']; ?>">
 
                     <label for="location-map-url">Map URL</label>
-                    <input type="text" id="location-map-url" name="new_location[mapurl]" value="<?php echo $post['location']['mapurl']; ?>">
+                    <input type="text" id="location-map-url" name="new_location[mapurl]" value="<?php echo $post['new_location']['mapurl']; ?>">
 
                     <label for="location-webpage">Webpage</label>
-                    <input type="text" id="location-webpage" name="new_location[webpageurl]" value="<?php echo $post['location']['webpageurl']; ?>">
+                    <input type="text" id="location-webpage" name="new_location[webpageurl]" value="<?php echo $post['new_location']['webpageurl']; ?>">
 
                     <label for="location-hours">Hours</label>
-                    <input type="text" id="location-hours" name="new_location[hours]" value="<?php echo $post['location']['hours']; ?>">
+                    <input type="text" id="location-hours" name="new_location[hours]" value="<?php echo $post['new_location']['hours']; ?>">
 
                     <label for="location-directions">Directions</label>
-                    <textarea id="location-directions" name="new_location[directions]"><?php echo $post['location']['directions']; ?></textarea>
+                    <textarea id="location-directions" name="new_location[directions]"><?php echo $post['new_location']['directions']; ?></textarea>
 
                     <label for="location-additional-public-info">Additional Public Info</label>
-                    <input type="text" id="location-additional-public-info" name="new_location[additionalpublicinfo]" value="<?php echo $post['location']['additionalpublicinfo']; ?>">
+                    <input type="text" id="location-additional-public-info" name="new_location[additionalpublicinfo]" value="<?php echo $post['new_location']['additionalpublicinfo']; ?>">
 
                     <label for="location-type">Type</label>
-                    <input type="text" id="location-type" name="new_location[type]" value="<?php echo $post['location']['type']; ?>">
+                    <input type="text" id="location-type" name="new_location[type]" value="<?php echo $post['new_location']['type']; ?>">
 
                     <label for="location-phone">Phone</label>
-                    <input type="text" id="location-phone" name="new_location[phone]" value="<?php echo $post['location']['phone']; ?>">
+                    <input type="text" id="location-phone" name="new_location[phone]" value="<?php echo $post['new_location']['phone']; ?>">
 
-                    <input <?php if ($post['location_save'] == 'on') echo 'checked="checked"'; ?> type="checkbox" id="location-save" name="location_save"> 
+                    <input <?php if (isset($post['location_save']) && $post['location_save'] == 'on') echo 'checked="checked"'; ?> type="checkbox" id="location-save" name="location_save">
                     <label for="location-save">Save this location for future events</label>
                 </div>
 
@@ -368,6 +368,20 @@ require(['jquery'], function ($) {
         if ($('#location').val() == 'new' && $('#location-name').val() == '') {
             notifier.mark_input_invalid($('#location-name'));
             errors.push('You must give your new location a <a href="#location-name">name</a>.');
+        }
+
+        //A room number is required if recommended to unl main calendar. Check the room number on the event or the room number on new location if created
+        if ($('#send-to-main').is(':checked')) {
+            if($('#room').val() == '' && $('#location-room').val() == '') {
+                notifier.mark_input_invalid($('#room'));
+                if($('#location').val() == 'new') {
+                    notifier.mark_input_invalid($('#location-room'));
+                    errors.push('You must give either a <a href="#room">event room</a> or your new location a <a href="#location-room">room</a> to recommend to UNL Main Calendar.');
+                }
+                else {
+                    errors.push('You must give a <a href="#room">room</a> to recommend to UNL Main Calendar.');
+                }
+            }
         }
 
         if (errors.length > 0) {


### PR DESCRIPTION
Added front-end javascript validation & back-end php validation to require a room or new-location-room (if a new custom location is used) when the manager checks the option "Consider for main UNL calendar".

Fixed the error-messages issue shown in the CreateEvent page. This issue happens when the manager checks "Consider for main UNL calendar" and specifies a new location and submit the event with missing contact info.