### PR TITLE
Allow deleting events via the API

### DIFF
--- a/src/UNL/UCBCN/API/GetEvent.php
+++ b/src/UNL/UCBCN/API/GetEvent.php
@@ -56,10 +56,18 @@ class GetEvent
 
     public function handlePost($post)
     {
-    	if (!$this->event->userCanEdit()) {
+        if (!$this->event->userCanEdit()) {
             throw new \Exception("You do not have permission to edit this event.", 403);
         }
-    	$this->updateEvent($post);
+
+        if (array_key_exists('delete', $post) && $post['delete'] === true) {
+            //This is a delete request
+            $this->event->delete();
+            return true;
+        } else {
+            $this->updateEvent($post);
+        }
+
         $this->event->imagedata = NULL;
         return $this->event;
     }


### PR DESCRIPTION
fixes #62 

Adds a method to delete an event via the api. To do so, you would POST `delete=true` to the `/api/{calendar}/event/{id}` endpoint. The result would be a json `true` value. 
