### PR TITLE
Improve the 'submit to main calendar' checkbox

### DIFF
--- a/www/templates/default/html/manager/CreateEvent.tpl.php
+++ b/www/templates/default/html/manager/CreateEvent.tpl.php
@@ -213,7 +213,7 @@
                 </legend>
                 <div class="details">
                     <fieldset>
-                        <legend class="wdn-text-hidden">Privacy</legend>
+                        <legend>Privacy</legend>
                         <label>
                             <input type="radio" value="private" name="private_public" id="sharing-private" <?php if ($post['private_public'] == 'private') echo 'checked="checked"'; ?>> 
                             Private
@@ -225,10 +225,18 @@
                         </label>
                     </fieldset>
 
-                    <label>
-                        <input <?php if (isset($post['send_to_main'])) echo 'checked="checked"'; ?> type="checkbox" name="send_to_main" id="send-to-main"> 
-                        Consider for main UNL calendar
-                    </label>
+                  <fieldset>
+                    <legend>Consider for main UNL Calendar</legend>
+                      <label>
+                        <input type="radio" name="send_to_main" value="on" required />
+                        Yes
+                      </label>
+                      <br>
+                      <label>
+                        <input type="radio" name="send_to_main" value="off" required />
+                        No
+                      </label>
+                  </fieldset>
                 </div>
             </fieldset>
 

--- a/www/templates/default/html/manager/EditEvent.tpl.php
+++ b/www/templates/default/html/manager/EditEvent.tpl.php
@@ -180,7 +180,7 @@
                 </legend>
                 <div class="details">
                     <fieldset>
-                        <legend class="wdn-text-hidden">Privacy</legend>
+                        <legend>Privacy</legend>
                         <label>
                             <input <?php if (!$event->approvedforcirculation) echo 'checked="checked"' ?> type="radio" value="private" name="private_public" id="sharing-private"> 
                             Private
@@ -191,15 +191,18 @@
                             Public
                         </label>
                     </fieldset>
-                    <?php if ($context->on_main_calendar): ?>
-                        <img src="<?php echo $base_frontend_url ?>templates/default/html/images/checkmark-16.png">
+                  <fieldset>
+                    <legend>Consider for main UNL Calendar</legend>
+                      <?php if ($context->on_main_calendar): ?>
+                        <img src="<?php echo $base_frontend_url ?>templates/default/html/images/checkmark-16.png" alt="">
                         (event has been sent to main UNL calendar for approval)
-                    <?php else: ?>
+                      <?php else: ?>
                         <label>
                             <input type="checkbox" <?php if (isset($post['send_to_main'])) echo 'checked="checked"'; ?> name="send_to_main" id="send-to-main"> 
-                            Consider for main UNL calendar
+                            Yes, please consider for the main calendar
                         </label>
-                    <?php endif; ?>
+                      <?php endif; ?>
+                  </fieldset>
                 </div>
             </fieldset>
 


### PR DESCRIPTION
User feedback suggests the users do not know about this checkbox or forget about it. By requiring a response to the question via form validation, we can alleviate this issue. We don't want to default to 'yes' because that might overwhelm the curator for the main calendar.

This requirement is only on the form to submit a new event. The form to edit an event will not require a response.