### PR TITLE
Fix pagination.css path and move select class to single class attribtue so javascript works

### DIFF
--- a/www/templates/default/html/manager/Calendar.tpl.php
+++ b/www/templates/default/html/manager/Calendar.tpl.php
@@ -265,7 +265,7 @@
 
             <?php if ($total_pages > 1): ?>
                 <?php
-                  $page->addScriptDeclaration("WDN.loadCSS(WDN.getTemplateFilePath('css/modules/pagination.css'));");
+                $page->addScriptDeclaration("WDN.loadCSS('https://unlcms.unl.edu/wdn/templates_4.1/css/modules/pagination.css');");
                 ?>
                 <div style="text-align: center;">
                     <div style="display: inline-block;">

--- a/www/templates/default/html/manager/EditEvent.tpl.php
+++ b/www/templates/default/html/manager/EditEvent.tpl.php
@@ -147,7 +147,7 @@
 
                 <?php if ($total_pages > 1): ?>
                 <?php
-                    $page->addScriptDelcaration("WDN.getTemplateFilePath('css/modules/pagination.css')");
+                    $page->addScriptDeclaration("WDN.loadCSS('https://unlcms.unl.edu/wdn/templates_4.1/css/modules/pagination.css');");
                 ?>
                 <div style="text-align: center;">
                     <div style="display: inline-block;">

--- a/www/templates/default/html/manager/Search.tpl.php
+++ b/www/templates/default/html/manager/Search.tpl.php
@@ -129,9 +129,8 @@
                                     <strong><?php echo ucwords($status); ?></strong> on <?php echo $context->calendar->name ?>
                                 <?php else: ?>
                                     <select
-                                        class="dcf-input-select"
                                         id="event-action-<?php echo $event->id ?>"
-                                        class="searched-event-tools"
+                                        class="dcf-input-select searched-event-tools"
                                         data-id="<?php echo $event->id; ?>"
                                     >
                                       <option value="">Select an Action</option>
@@ -159,7 +158,7 @@
 
         <?php if ($total_pages > 1): ?>
             <?php
-              $page->addScriptDeclaration("WDN.loadCSS(WDN.getTemplateFilePath('css/modules/pagination.css'));");
+            $page->addScriptDeclaration("WDN.loadCSS('https://unlcms.unl.edu/wdn/templates_4.1/css/modules/pagination.css');");
             ?>
             <div style="text-align: center;">
                 <div style="display: inline-block;">


### PR DESCRIPTION
Fixes bug in events manager where searched events could not be moved to pending or upcoming due to two class attributes on select input causing javascript onchange event not to fire.

Also cleaned up some pagination.css paths.  Was targeting 5.0 templates but class DNE there so referencing 4.1 version for now.