### PR TITLE
Optimize queries

### DIFF
--- a/data/20190318_add_reccurring_date_indexes.sql
+++ b/data/20190318_add_reccurring_date_indexes.sql
@@ -1,0 +1,4 @@
+CREATE  INDEX `going_lookup_idx` ON `recurringdate` (`event_datetime_id`, `ongoing`, `recurrence_id`);
+CREATE  INDEX `event_date_lookup_idx` ON `recurringdate` (`event_id`, `recurring_date`);
+
+

--- a/src/UNL/UCBCN/ActiveRecord/Record.php
+++ b/src/UNL/UCBCN/ActiveRecord/Record.php
@@ -217,10 +217,20 @@ abstract class Record
      *
      * @return false | Record
      */
-    public static function getRecordByID($table, $id, $field = 'id')
+    public static function getRecordByID($table, $id, $field = 'id', $fields = array())
     {
+
+        if (empty($fields)) {
+            $fields = array_keys(get_class_vars($class));
+        }
+
+        $fieldList = '*';
+        if (is_array($fields)) {
+            $fieldList = implode(", ", $fields);
+        }
         $mysqli = self::getDB();
-        $sql    = "SELECT * FROM $table WHERE $field = ".intval($id).' LIMIT 1;';
+        $sql    = "SELECT " . $fieldList . " FROM $table WHERE $field = ".intval($id).' LIMIT 1;';
+
         if ($result = $mysqli->query($sql)) {
             return $result->fetch_assoc();
         }
@@ -280,22 +290,34 @@ abstract class Record
             if (isset($args[1])) {
                 $whereAdd = $args[1];
             }
+            $fields = array();
+            if (isset($args[2]) && is_array($args[2])) {
+                $fields = $args[2];
+            }
 
-            return self::getByAnyField($class, $field, $args[0], $whereAdd);
+            return self::getByAnyField($class, $field, $args[0], $whereAdd, $fields);
             break;
         }
         throw new Exception('Invalid static method called.', 500);
     }
 
-    public static function getByAnyField($class, $field, $value, $whereAdd = '') {
+    public static function getByAnyField($class, $field, $value, $whereAdd = '', $fields = array()) {
         $record = new $class;
 
         if (!empty($whereAdd)) {
             $whereAdd = $whereAdd . ' AND ';
         }
 
+        if (empty($fields)) {
+            $fields = array_keys(get_class_vars($class));
+        }
+
+        $fieldList = '*';
+        if (is_array($fields)) {
+           $fieldList = implode(", ", $fields);
+        }
         $mysqli = self::getDB();
-        $sql    = 'SELECT * FROM '
+        $sql    = 'SELECT ' . $fieldList . ' FROM '
                     . $record->getTable()
                     . ' WHERE '
                     . $whereAdd

--- a/src/UNL/UCBCN/Event/Occurrence.php
+++ b/src/UNL/UCBCN/Event/Occurrence.php
@@ -248,8 +248,12 @@ class Occurrence extends Record
      *
      * @return \UNL\UCBCN\Event
      */
-    public function getEvent()
+    public function getEvent($includeImageData = FALSE)
     {
-        return Event::getById($this->event_id);
+        $fields = array_keys(get_class_vars(get_class(new Event)));
+        if ($includeImageData === FALSE) {
+            $fields = array_diff($fields, array('imagedata'));
+        }
+        return Event::getById($this->event_id, NULL, $fields);
     }
 }

--- a/src/UNL/UCBCN/Frontend/Controller.php
+++ b/src/UNL/UCBCN/Frontend/Controller.php
@@ -204,6 +204,7 @@ class Controller
         $options['d'] = $datetime->format('d');
         $options['m'] = $datetime->format('m');
         $options['y'] = $datetime->format('Y');
+        $this->options['includeEventImageData'] = TRUE;
 
         return new Day($options);
     }

--- a/src/UNL/UCBCN/Frontend/Day.php
+++ b/src/UNL/UCBCN/Frontend/Day.php
@@ -40,6 +40,9 @@ class Day extends EventListing implements RoutableInterface
         $this->options['m'] = date('m');
         $this->options['d'] = date('d');
         $this->options['y'] = date('Y');
+        if (!isset($this->options['includeEventImageData'])) {
+            $this->options['includeEventImageData'] = TRUE;
+        }
 
         parent::__construct($options);
     }

--- a/src/UNL/UCBCN/Frontend/DayIterator.php
+++ b/src/UNL/UCBCN/Frontend/DayIterator.php
@@ -21,6 +21,7 @@ class DayIterator extends \IteratorIterator
              'y' => $datetime->format('Y'),
              'd' => $datetime->format('d'),
              'calendar' => $this->calendar,
+             'includeEventImageData' => FALSE
          );
          
          return new Day($options);

--- a/src/UNL/UCBCN/Frontend/EventInstance.php
+++ b/src/UNL/UCBCN/Frontend/EventInstance.php
@@ -72,7 +72,8 @@ class EventInstance implements RoutableInterface
             );
         }
 
-        $this->event = $this->eventdatetime->getEvent();
+        // get event with image data if includeEventImageData is not set or is TRUE
+        $this->event = $this->eventdatetime->getEvent(!isset($options['includeEventImageData']) || $options['includeEventImageData'] === TRUE);
         $this->options = $options;
     }
 

--- a/src/UNL/UCBCN/Frontend/Upcoming.php
+++ b/src/UNL/UCBCN/Frontend/Upcoming.php
@@ -50,6 +50,7 @@ class Upcoming extends EventListing implements RoutableInterface
         $options['m'] = date('m');
         $options['d'] = date('d');
         $options['y'] = date('Y');
+        $options['includeEventImageData'] = TRUE;
 
         parent::__construct($options);
     }


### PR DESCRIPTION
* Documented new  indexes for recurringdate table
* Updated ActiveRecord `getRecordByID` and `getByAnyField` to not do select * queries since they are not efficient.  The field list/columns selected will be passed in or derived from object being queried.
* Update event queries to only include `imagedata` blob in queries where event image is likely to be needed.  Not including blob in necessary queries should make queries faster.


I also cleaned up a bunch of bad data from the live DB, which included orphaned rows and rows with invalid or null event dates.