### PR TITLE
Bug Fix: API Create Event

### DIFF
--- a/src/UNL/UCBCN/API/CreateEvent.php
+++ b/src/UNL/UCBCN/API/CreateEvent.php
@@ -60,7 +60,7 @@ class CreateEvent
         }
 
         # timezone must be valid
-        if (empty($post_data['timezone']) || !(in_array($post_data['timezone'], UNL\UCBCN::getTimezoneOptions()))) {
+        if (!empty($post_data['timezone']) && !(in_array($post_data['timezone'], \UNL\UCBCN::getTimezoneOptions()))) {
             throw new ValidationException('The timezone is invalid.');
         }
 
@@ -98,7 +98,7 @@ class CreateEvent
         $event_datetime->location_id = $post_data['location'];
 
         # set the start date and end date
-        $event_datetime->timezone = empty($post_data['timezone']) ? UNL\UCBCN::$defaultTimezone : $post_data['timezone'];
+        $event_datetime->timezone = empty($post_data['timezone']) ? \UNL\UCBCN::$defaultTimezone : $post_data['timezone'];
         $event_datetime->starttime = date('Y-m-d H:i:s', strtotime($post_data['start_time']));
         $event_datetime->endtime = date('Y-m-d H:i:s', strtotime($post_data['end_time']));
 


### PR DESCRIPTION
- Allow timezone to default to calendar default
- Fix   \UNL\UCBCN::getTimezoneOptions reference
- Correctly validate timezone if provided