### PR TITLE
Update DateTime form recurring event check label display

### DIFF
--- a/www/templates/default/html/manager/AddDatetime.tpl.php
+++ b/www/templates/default/html/manager/AddDatetime.tpl.php
@@ -224,8 +224,9 @@
 
         <?php if ($context->recurrence_id == NULL) : ?>
             <div class="section-container">
-                <input <?php if ($datetime->recurringtype != 'none' && $datetime->recurringtype != NULL) echo 'checked="checked"' ?> type="checkbox" name="recurring" id="recurring"> 
-                <label class="dcf-label" for="recurring">This is a recurring <?php echo $datetime->recurringtype; ?> event</label>
+                <input <?php if ($datetime->recurringtype != 'none' && $datetime->recurringtype != NULL) echo 'checked="checked"' ?> type="checkbox" name="recurring" id="recurring">
+                <?php $recurringType = (empty($datetime->recurringtype) || strtolower($datetime->recurringtype) == 'none') ? '' : $datetime->recurringtype; ?>
+                <label class="dcf-label" for="recurring">This is a recurring <?php echo $recurringType; ?> event</label>
                 <div class="recurring-container date-time-select">                        
                     <label class="dcf-label dcf-d-inline-block" for="recurring-type">This event recurs </label>
                     <select class="dcf-input-select" id="recurring-type" name="recurring_type">


### PR DESCRIPTION
Update to fix confusing checkbox label.  Updated to not display `none` as a recurring event type when editing a non-recurring event's DateTime.

When making an event on UNL Events, there's a checkbox that says 'This is a recurring none event'. I think 'none' then becomes 'daily', 'monthly', etc. after the event is saved.

Any chance the 'none' could be dropped? Or have it update when the recurrence is selected instead of after saving? A co-worker and I were pretty confused about this when trying to troubleshoot an event posting. (edited)
