### PR TITLE
Revert month widget to match updated javascript nav fix

### DIFF
--- a/www/templates/default/html/MonthWidget.tpl.php
+++ b/www/templates/default/html/MonthWidget.tpl.php
@@ -5,15 +5,11 @@ $next = $context->getDateTime()->modify('+1 month');
 <div class="monthwidget">
     <table class="wp-calendar dcf-txt-sm unl-font-sans" data-datetime="<?php echo $context->getDateTime()->format('c') ?>">
         <caption class="dcf-pb-0 dcf-txt-sm dcf-regular unl-ls-0 unl-bg-darker-gray">
-            <span class="dcf-d-flex dcf-flex-nowrap dcf-ai-center">
-                <a class="dcf-p-4 unl-cream prev" href="<?php echo $context->getPreviousMonthURL(); ?>" aria-label="View events for <?php echo $prev->format('F'); ?>"><svg class="dcf-d-block dcf-h-4 dcf-w-4 dcf-fill-current" focusable="false" width="24" height="24" viewBox="0 0 24 24"><path d="M12 .004c-6.617 0-12 5.383-12 12s5.383 12 12 12 12-5.383 12-12-5.384-12-12-12zm3 8.5a.5.5 0 01-.193.395l-3.993 3.105 3.993 3.106c.122.094.193.24.193.394v4a.5.5 0 01-.82.384l-9-7.5a.499.499 0 010-.768l9-7.5a.5.5 0 01.82.384v4z"></path></svg></a>
-                <span class="dcf-flex-grow-1 dcf-d-flex dcf-ai-center dcf-jc-flex-end monthvalue">
-                    <a class="dcf-txt-right dcf-pt-4 dcf-pr-1 dcf-pb-4 dcf-pl-4 dcf-uppercase dcf-txt-decor-hover unl-cream" href="<?php echo $context->getURL(); ?>"><?php echo $context->getDateTime()->format('F'); ?></a>
-                </span>
-                <span class="dcf-flex-grow-1 dcf-d-flex dcf-ai-center yearvalue">
-                    <a class="dcf-txt-left dcf-pt-4 dcf-pr-4 dcf-pb-4 dcf-txt-decor-hover unl-cream" href="<?php echo $context->getYearURL(); ?>"><?php echo $context->getDateTime()->format('Y'); ?></a>
-                </span>
-                <a class="dcf-p-4 unl-cream next" href="<?php echo $context->getNextMonthURL(); ?>" aria-label="View events for <?php echo $next->format('F'); ?>"><svg class="dcf-d-block dcf-h-4 dcf-w-4 dcf-fill-current" focusable="false" width="24" height="24" viewBox="0 0 24 24"><path d="M12 .004c-6.617 0-12 5.383-12 12s5.383 12 12 12 12-5.383 12-12-5.384-12-12-12zm6.82 12.384l-8.999 7.5a.498.498 0 01-.532.069.5.5 0 01-.289-.453v-4c0-.154.071-.3.193-.394l3.992-3.106-3.992-3.106A.497.497 0 019 8.504v-4a.5.5 0 01.82-.384l8.999 7.5a.499.499 0 01.001.768z"></path></svg></a>
+            <span class="dcf-d-flex dcf-flex-nowrap dcf-ai-center dcf-jc-between">
+                <a class="dcf-flex-grow-1 dcf-txt-left dcf-p-4 unl-cream prev" href="<?php echo $context->getPreviousMonthURL(); ?>" aria-label="View events for <?php echo $prev->format('F'); ?>"><svg class="dcf-d-block dcf-h-4 dcf-w-4 dcf-fill-current" focusable="false" width="24" height="24" viewBox="0 0 24 24"><path d="M12 .004c-6.617 0-12 5.383-12 12s5.383 12 12 12 12-5.383 12-12-5.384-12-12-12zm3 8.5a.5.5 0 01-.193.395l-3.993 3.105 3.993 3.106c.122.094.193.24.193.394v4a.5.5 0 01-.82.384l-9-7.5a.499.499 0 010-.768l9-7.5a.5.5 0 01.82.384v4z"></path></svg></a>
+                <a class="dcf-flex-grow-1 dcf-txt-right dcf-pt-4 dcf-pr-1 dcf-pb-4 dcf-pl-4 dcf-uppercase dcf-txt-decor-hover unl-cream" href="<?php echo $context->getURL(); ?>"><?php echo $context->getDateTime()->format('F'); ?></a>
+                <a class="dcf-flex-grow-1 dcf-txt-left dcf-pt-4 dcf-pr-4 dcf-pb-4 dcf-txt-decor-hover unl-cream" href="<?php echo $context->getYearURL(); ?>"><?php echo $context->getDateTime()->format('Y'); ?></a>
+                <a class="dcf-flex-grow-1 dcf-p-4 unl-cream next" href="<?php echo $context->getNextMonthURL(); ?>" aria-label="View events for <?php echo $next->format('F'); ?>"><svg class="dcf-float-right dcf-h-4 dcf-w-4 dcf-fill-current next" focusable="false" width="24" height="24" viewBox="0 0 24 24"><path d="M12 .004c-6.617 0-12 5.383-12 12s5.383 12 12 12 12-5.383 12-12-5.384-12-12-12zm6.82 12.384l-8.999 7.5a.498.498 0 01-.532.069.5.5 0 01-.289-.453v-4c0-.154.071-.3.193-.394l3.992-3.106-3.992-3.106A.497.497 0 019 8.504v-4a.5.5 0 01.82-.384l8.999 7.5a.499.499 0 01.001.768z"></path></svg></a>
             </span>
         </caption>
         <thead>


### PR DESCRIPTION
The latest javascript fix fixed-site month nav but broke the month widget that had its markup updated instead of fixing javascript.  This update syncs both markups.