### PR TITLE
Display origin calendar info for event

### DIFF
--- a/src/UNL/UCBCN/Frontend/EventInstance.php
+++ b/src/UNL/UCBCN/Frontend/EventInstance.php
@@ -250,6 +250,7 @@ class EventInstance implements RoutableInterface
         $webcasts   = $this->event->getWebcasts();
         $documents  = $this->event->getDocuments();
         $contacts   = $this->event->getPublicContacts();
+        $originCalendar = $this->event->getOriginCalendar();
         $data       = array();
 
 
@@ -452,6 +453,17 @@ class EventInstance implements RoutableInterface
         if (!empty($this->event->privatecomment)) {
             $data['PrivateComments'] = array(
                 0 => $this->event->privatecomment,
+            );
+        }
+
+        if ($originCalendar instanceof \UNL\UCBCN\Calendar) {
+            $protocol = !empty($_SERVER['HTTPS']) ? 'https://' : 'http://';
+            $data['OriginCalendar'] = array(
+                'CalendarID' => $originCalendar->id,
+                'AccountID' => $originCalendar->account_id,
+                'Name' => $originCalendar->name,
+                'ShortName' => $originCalendar->shortname,
+                'URL' =>   $protocol . $_SERVER['SERVER_NAME'] . '/' . urlencode($originCalendar->shortname)
             );
         }
 

--- a/www/templates/default/hcalendar/EventInstance.tpl.php
+++ b/www/templates/default/hcalendar/EventInstance.tpl.php
@@ -41,6 +41,8 @@
             <p class="download">
                 <a class="dcf-btn dcf-btn-primary" href="<?php echo $url ?>.ics">Download this event to my calendar</a>
             </p>
+
+            <?php echo $savvy->render($context, 'EventInstance/OriginCalendar.tpl.php') ?>
         </div>
     </div>
 </div>

--- a/www/templates/default/html/EventInstance/OriginCalendar.tpl.php
+++ b/www/templates/default/html/EventInstance/OriginCalendar.tpl.php
@@ -1,0 +1,14 @@
+<?php
+
+use UNL\UCBCN\Frontend\Controller;
+
+$originCalendar = $context->event->getOriginCalendar();
+if (!empty($context->calendar->id) && !empty($originCalendar->id) && $context->calendar->id != $originCalendar->id): ?>
+    <?php
+        $name = $savvy->dbStringtoHtml($originCalendar->name);
+        $name = $savvy->linkify($name);
+    ?>
+    <div class="dcf-mt-6 dcf-txt-2xs">
+        This event originated in <a href="<?php echo Controller::$url . urlencode($originCalendar->shortname); ?>"><?php echo $name; ?></a>.
+    </div>
+<?php endif; ?>

--- a/www/templates/default/html/EventInstance/OriginCalendar.tpl.php
+++ b/www/templates/default/html/EventInstance/OriginCalendar.tpl.php
@@ -8,7 +8,5 @@ if (!empty($context->calendar->id) && !empty($originCalendar->id) && $context->c
         $name = $savvy->dbStringtoHtml($originCalendar->name);
         $name = $savvy->linkify($name);
     ?>
-    <div class="dcf-mt-6 dcf-txt-2xs">
-        This event originated in <a href="<?php echo Controller::$url . urlencode($originCalendar->shortname); ?>"><?php echo $name; ?></a>.
-    </div>
+    <div><small class="dcf-txt-2xs">This event originated in <a href="<?php echo Controller::$url . urlencode($originCalendar->shortname); ?>"><?php echo $name; ?></a>.</small></div>
 <?php endif; ?>

--- a/www/templates/default/html/EventListing.tpl.php
+++ b/www/templates/default/html/EventListing.tpl.php
@@ -34,6 +34,7 @@
               <?php echo $savvy->render($eventinstance, 'EventInstance/Date.tpl.php') ?>
               <?php echo $savvy->render($eventinstance, 'EventInstance/Location.tpl.php') ?>
               <?php echo $savvy->render($eventinstance, 'EventInstance/Description.tpl.php') ?>
+              <?php echo $savvy->render($eventinstance, 'EventInstance/OriginCalendar.tpl.php') ?>
           <?php } // end else ?>
         </div>
         <?php

--- a/www/templates/default/xml/EventInstance.tpl.php
+++ b/www/templates/default/xml/EventInstance.tpl.php
@@ -238,8 +238,8 @@
             <OriginCalendar>
                 <CalendarID><?php echo $originCalendar->id; ?></CalendarID>
                 <AccountID><?php echo $originCalendar->account_id; ?></AccountID>
-                <Name><?php echo $originCalendar->name; ?></Name>
-                <ShortName><?php echo $originCalendar->shortname; ?></ShortName>
+                <Name><?php echo htmlspecialchars($originCalendar->name); ?></Name>
+                <ShortName><?php echo htmlspecialchars($originCalendar->shortname); ?></ShortName>
                 <URL><?php echo $protocol . $_SERVER['SERVER_NAME'] . '/' . urlencode($originCalendar->shortname);?></URL>
             </OriginCalendar>
         <?php endif; ?>

--- a/www/templates/default/xml/EventInstance.tpl.php
+++ b/www/templates/default/xml/EventInstance.tpl.php
@@ -230,4 +230,17 @@
             <PrivateComment><?php echo htmlspecialchars($context->event->privatecomment); ?></PrivateComment>
         </PrivateComments>
         <?php endif; ?>
+        <?php
+        $originCalendar = $context->event->getOriginCalendar();
+        $protocol = !empty($_SERVER['HTTPS']) ? 'https://' : 'http://';
+        ?>
+        <?php if ($originCalendar instanceof \UNL\UCBCN\Calendar): ?>
+            <OriginCalendar>
+                <CalendarID><?php echo $originCalendar->id; ?></CalendarID>
+                <AccountID><?php echo $originCalendar->account_id; ?></AccountID>
+                <Name><?php echo $originCalendar->name; ?></Name>
+                <ShortName><?php echo $originCalendar->shortname; ?></ShortName>
+                <URL><?php echo $protocol . $_SERVER['SERVER_NAME'] . '/' . urlencode($originCalendar->shortname);?></URL>
+            </OriginCalendar>
+        <?php endif; ?>
     </Event>


### PR DESCRIPTION
This is an update to address the following request: `When viewing an individual event, tell which calendar an event belongs to`. 

You can test on https://events-dev.unl.edu

Examples
* https://events-dev.unl.edu/2020/11/30/
* https://events-dev.unl.edu/2020/11/30/121939/
* https://events-dev.unl.edu/2020/11/30/121939/.json
* https://events-dev.unl.edu/2020/11/30/121939/.xml

Note the HTML display will only occur if the event did not originate on the current calendar.
