### PR TITLE
Added delete button on edit page

### DIFF
--- a/src/UNL/UCBCN/Manager/DeleteEvent.php
+++ b/src/UNL/UCBCN/Manager/DeleteEvent.php
@@ -39,9 +39,11 @@ class DeleteEvent extends PostHandler
                 $backend_tab_name = 'pending';
                 break;
             case 'upcoming':
+            case 'posted':
                 $backend_tab_name = 'posted';
                 break;
             case 'past':
+            case 'archived':
                 $backend_tab_name = 'archived';
                 break;
             default:

--- a/src/UNL/UCBCN/Manager/EditEvent.php
+++ b/src/UNL/UCBCN/Manager/EditEvent.php
@@ -7,6 +7,7 @@ use UNL\UCBCN\Event\EventType;
 use UNL\UCBCN\Event\Audience;
 use UNL\UCBCN\Calendar as CalendarModel;
 use UNL\UCBCN\Calendar\EventType as ValidateEventType;
+use UNL\UCBCN\Calendar\Event as CalendarEvent;
 
 class EditEvent extends EventForm
 {
@@ -37,6 +38,18 @@ class EditEvent extends EventForm
 
         $main_calendar = CalendarModel::getByID(Controller::$default_calendar_id);
         $this->on_main_calendar = $this->event->getStatusWithCalendar($main_calendar);
+    }
+
+    public function getCalendar()
+    {
+        return $this->calendar;
+    }
+
+    public function getEventCalendarStatus()
+    {
+        $calendarEvent = CalendarEvent::getByIds($this->calendar->id, $this->event->id);
+
+        return $calendarEvent === false ? false : $calendarEvent->status;
     }
 
     public function handlePost(array $get, array $post, array $files)

--- a/www/templates/default/html/manager/EditEvent.tpl.php
+++ b/www/templates/default/html/manager/EditEvent.tpl.php
@@ -974,42 +974,55 @@
 
     <button class="dcf-btn dcf-btn-primary" type="submit">Save Event</button>
     <button
-            id="google-microdata-button"
-            class="dcf-btn-toggle-modal dcf-btn unl-bg-blue events-b-blue unl-cream dcf-mt-3"
-            title="Learn More"
-            type="button"
-            data-toggles-modal="google-microdata-modal"
-            disabled
-        >
-            ! Your event does not reach microdata requirements !
-        </button>
+        class="dcf-btn dcf-btn-secondary"
+        type="submit"
+        form="delete-form"
+        onclick="return confirm('Are you sure you want to delete this event?');"
+    >Delete Event</button>
+    <br>
+    <button
+        id="google-microdata-button"
+        class="dcf-btn-toggle-modal dcf-btn unl-bg-blue events-b-blue unl-cream dcf-mt-3"
+        title="Learn More"
+        type="button"
+        data-toggles-modal="google-microdata-modal"
+        disabled
+    >
+        ! Your event does not reach microdata requirements !
+    </button>
 
-        <div class="dcf-modal" id="google-microdata-modal" hidden>
-            <div class="dcf-modal-wrapper">
-                <div class="dcf-modal-header">
-                    <h2>Info About Microdata</h2>
-                    <button class="dcf-btn-close-modal">Close</button>
-                </div>
-                <div class="dcf-modal-content">
-                <p>
-                        Microdata is a way to provide structured data markup
-                        on web pages. This structured data helps search engines, like Google,
-                        to understand the content and context of the page better.
-                        For events.unl.edu, microdata can provide key information about
-                        each event such as it's name, date, time, location, description, and more.
-                        This helps search engines present our events
-                        more prominently in search results, making it easier for users to find
-                        relevant events.
+    <div class="dcf-modal" id="google-microdata-modal" hidden>
+        <div class="dcf-modal-wrapper">
+            <div class="dcf-modal-header">
+                <h2>Info About Microdata</h2>
+                <button class="dcf-btn-close-modal">Close</button>
+            </div>
+            <div class="dcf-modal-content">
+            <p>
+                    Microdata is a way to provide structured data markup
+                    on web pages. This structured data helps search engines, like Google,
+                    to understand the content and context of the page better.
+                    For events.unl.edu, microdata can provide key information about
+                    each event such as it's name, date, time, location, description, and more.
+                    This helps search engines present our events
+                    more prominently in search results, making it easier for users to find
+                    relevant events.
 
-                        <a href="https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data">
-                            Learn more through Google's documentation.
-                        </a>
-                    </p>
-                    <div class="dcf-mt-5" id="google-microdata-modal-output"></div>
-                    <p class="dcf-txt-xs">*If this information is not relevant to you, feel free to disregard it.</p>
-                </div>
+                    <a href="https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data">
+                        Learn more through Google's documentation.
+                    </a>
+                </p>
+                <div class="dcf-mt-5" id="google-microdata-modal-output"></div>
+                <p class="dcf-txt-xs">*If this information is not relevant to you, feel free to disregard it.</p>
             </div>
         </div>
+    </div>
+</form>
+
+<form id="delete-form" method="POST" action="<?php echo $event->getDeleteURL($context->getCalendar()) ?>" class="dcf-d-none">
+    <input type="text" name="status" value="<?php echo $context->getEventCalendarStatus(); ?>">
+    <input type="hidden" name="<?php echo $controller->getCSRFHelper()->getTokenNameKey() ?>" value="<?php echo $controller->getCSRFHelper()->getTokenName() ?>" />
+    <input type="hidden" name="<?php echo $controller->getCSRFHelper()->getTokenValueKey() ?>" value="<?php echo $controller->getCSRFHelper()->getTokenValue() ?>">
 </form>
 
 <?php


### PR DESCRIPTION
Sometimes you can lose an event in the lists of events on the manager pages. This will let you find events using the calendar and delete them when you click 'Edit Event'.

Changes: 

- Added delete button on edit page

Fixes #220 