### PR TITLE
Remove all day

### DIFF
--- a/src/UNL/UCBCN/Frontend/EventListing.php
+++ b/src/UNL/UCBCN/Frontend/EventListing.php
@@ -18,7 +18,7 @@ class EventListing extends RecordList
     public $event_type_filter = '';
     public $audience_filter = '';
     public $needs_location = false;
-    public $not_TDB = false;
+    public $time_mode_filter = '';
 
     /**
      * Constructor for an individual day.
@@ -36,7 +36,7 @@ class EventListing extends RecordList
         $this->event_type_filter = $options['type'] ?? "";
         $this->audience_filter = $options['audience'] ?? "";
         $this->needs_location = $options['needs_location'] ?? false;
-        $this->not_TDB = $options['not_TDB'] ?? false;
+        $this->time_mode_filter = $options['time_mode'] ?? "";
 
         parent::__construct($options);
     }
@@ -186,11 +186,11 @@ class EventListing extends RecordList
      * Gets an SQL string to be used in the where clause
      *
      * @param string $sqlEventDateTimeTable Name of the eventdatetime table or alias
-     * @return string Not TBD filter SQL
+     * @return string Time mode filter SQL
      */
-    public function getNotTDBSQL(string $sqlEventDateTimeTable): string
+    public function getTimeModeSQL(string $sqlEventDateTimeTable): string
     {
-        return '(' . $sqlEventDateTimeTable . '.timemode != "' . Occurrence::TIME_MODE_TBD . '")';
+        return $this->getFilterSQL($sqlEventDateTimeTable, "timemode", $this->time_mode_filter);
     }
 
     /**

--- a/src/UNL/UCBCN/Frontend/EventListing.php
+++ b/src/UNL/UCBCN/Frontend/EventListing.php
@@ -4,6 +4,7 @@ namespace UNL\UCBCN\Frontend;
 use UNL\UCBCN\ActiveRecord\RecordList;
 use UNL\UCBCN\Calendar\Audiences;
 use UNL\UCBCN\Calendar\EventTypes;
+use UNL\UCBCN\Event\Occurrence;
 
 class EventListing extends RecordList
 {
@@ -16,6 +17,8 @@ class EventListing extends RecordList
 
     public $event_type_filter = '';
     public $audience_filter = '';
+    public $needs_location = false;
+    public $not_TDB = false;
 
     /**
      * Constructor for an individual day.
@@ -32,6 +35,8 @@ class EventListing extends RecordList
 
         $this->event_type_filter = $options['type'] ?? "";
         $this->audience_filter = $options['audience'] ?? "";
+        $this->needs_location = $options['needs_location'] ?? false;
+        $this->not_TDB = $options['not_TDB'] ?? false;
 
         parent::__construct($options);
     }
@@ -164,6 +169,28 @@ class EventListing extends RecordList
     public function getAudienceSQL(string $sqlAudienceTable): string
     {
         return $this->getFilterSQL($sqlAudienceTable, "name", $this->audience_filter);
+    }
+
+    /**
+     * Gets an SQL string to be used in the where clause
+     *
+     * @param string $sqlEventDateTimeTable Name of the eventdatetime table or alias
+     * @return string Needs location filter SQL
+     */
+    public function getNeedsLocationSQL(string $sqlEventDateTimeTable): string
+    {
+        return '(' . $sqlEventDateTimeTable . '.location_id IS NOT NULL OR ' . $sqlEventDateTimeTable . '.webcast_id IS NOT NULL)';
+    }
+
+    /**
+     * Gets an SQL string to be used in the where clause
+     *
+     * @param string $sqlEventDateTimeTable Name of the eventdatetime table or alias
+     * @return string Not TBD filter SQL
+     */
+    public function getNotTDBSQL(string $sqlEventDateTimeTable): string
+    {
+        return '(' . $sqlEventDateTimeTable . '.timemode != "' . Occurrence::TIME_MODE_TBD . '")';
     }
 
     /**

--- a/src/UNL/UCBCN/Frontend/Upcoming.php
+++ b/src/UNL/UCBCN/Frontend/Upcoming.php
@@ -139,6 +139,18 @@ class Upcoming extends EventListing implements RoutableInterface, MetaTagInterfa
             $sql .= $this->getAudienceSQL('audience');
         }
 
+        // Adds filters for needs location
+        if ($this->needs_location) {
+            $sql .= 'AND ';
+            $sql .= $this->getNeedsLocationSQL('e');
+        }
+
+        // Adds filters for Not TDB
+        if ($this->not_TDB) {
+            $sql .= 'AND ';
+            $sql .= $this->getNotTDBSQL('e');
+        }
+
         $sql .= '
                 ORDER BY (
                         IF (recurringdate.recurringdate IS NULL,

--- a/src/UNL/UCBCN/Frontend/Upcoming.php
+++ b/src/UNL/UCBCN/Frontend/Upcoming.php
@@ -145,10 +145,10 @@ class Upcoming extends EventListing implements RoutableInterface, MetaTagInterfa
             $sql .= $this->getNeedsLocationSQL('e');
         }
 
-        // Adds filters for Not TDB
-        if ($this->not_TDB) {
+        // Adds filters for time mode
+        if ($this->time_mode_filter) {
             $sql .= 'AND ';
-            $sql .= $this->getNotTDBSQL('e');
+            $sql .= $this->getTimeModeSQL('e');
         }
 
         $sql .= '

--- a/www/templates/default/html/manager/EventFormDateTime.tpl.php
+++ b/www/templates/default/html/manager/EventFormDateTime.tpl.php
@@ -101,7 +101,7 @@
                 Event Time Type
                 <small class="dcf-required">Required</small>
             </legend>
-            <div class="dcf-grid dcf-grid-full dcf-grid-halves@sm dcf-grid-thirds@md dcf-col-gap-vw">
+            <div class="dcf-grid dcf-grid-full dcf-grid-halves dcf-col-gap-vw">
                 <div class="dcf-input-radio">
                     <input id="<?php echo $time_mode_regular; ?>" name="time_mode" type="radio" value="<?php echo $time_mode_regular; ?>" <?php if ($time_mode === $time_mode_regular) { echo 'checked'; }?>>
                     <label for="<?php echo $time_mode_regular; ?>">Start & End</label>
@@ -113,10 +113,6 @@
                 <div class="dcf-input-radio">
                     <input id="<?php echo $time_mode_end_time_only; ?>" name="time_mode" type="radio" value="<?php echo $time_mode_end_time_only; ?>" <?php if ($time_mode === $time_mode_end_time_only) { echo 'checked'; }?>>
                     <label for="<?php echo $time_mode_end_time_only; ?>">End Time Only <br><span class="dcf-txt-xs">(e.g. Deadlines, Applicant Submissions)</span></label>
-                </div>
-                <div class="dcf-input-radio">
-                    <input id="<?php echo $time_mode_all_day; ?>" name="time_mode" type="radio" value="<?php echo $time_mode_all_day; ?>" <?php if ($time_mode === $time_mode_all_day) { echo 'checked'; }?>>
-                    <label for="<?php echo $time_mode_all_day; ?>">All Day</label>
                 </div>
                 <div class="dcf-input-radio">
                     <input id="<?php echo $time_mode_tbd; ?>" name="time_mode" type="radio" value="<?php echo $time_mode_tbd; ?>" <?php if ($time_mode === $time_mode_tbd) { echo 'checked'; }?>>


### PR DESCRIPTION
All day events are clogging up event feeds due to users using the time mode inappropriately. Also added new filters to go along with that change to get better event feeds.

Changes:

- Remove All Day time mode
- Added needs_location filter on upcoming events
- Added time_mode filter on upcoming events